### PR TITLE
Add 'npm install' to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ To develop locally you need ruby gems & bundler installed.
     sudo gem install bundler
 ```
 
-Then install all dependency by calling bundle install while in the source directory:
+Then install all dependencies by calling bundle/npm install while in the source directory:
 ```bash
     bundle install
+    npm install
 ```
 
 To compile the files call rake while in the source tree:


### PR DESCRIPTION
Without a call to `npm install` there is an error executing the Rakefile

```
Error: Cannot find module 'ent'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.Module._load (internal/modules/cjs/loader.js:506:25)
    at Module.require (internal/modules/cjs/loader.js:636:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/mnt/windows/data/projects/misc/gdg/devfest-at-site/automation/json/mobile.js:8:11)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
internal/modules/cjs/loader.js:582
    throw err;
    ^
```